### PR TITLE
Redirect daily report emails from needotron

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -10,9 +10,9 @@ class ReportMailer < ActionMailer::Base
 
     case Plek.current.environment
     when 'preview'
-      email_address = 'govuk-dev@digital.cabinet-office.gov.uk'
+      email_address = 'needotron-daily+preview@digital.cabinet-office.gov.uk'
     else
-      email_address = 'govuk-team@digital.cabinet-office.gov.uk'
+      email_address = 'needotron-daily+production@digital.cabinet-office.gov.uk'
     end
 
     mail(:to => email_address, :subject => analytics_subject(daily, weekly))


### PR DESCRIPTION
This commit moves the annoying daily emails which everyone except @jystewart filters to the bin into an opt-in list rather than govuk-dev and govuk-team.

It is an alternative to https://github.com/alphagov/need-o-tron/pull/9
