### PR TITLE
Correctly display timestamps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ require 'ci/reporter/rake/rspec' if Rails.env.test?
 NeedOTron::Application.load_tasks
 
 Rake::Task[:default].clear_prerequisites if Rake::Task.task_defined?(:default)
-task :default => [ :spec, "spec:acceptance" ]
+task :default => [ :spec, "spec:acceptance", :check_for_bad_time_handling ]

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -111,14 +111,14 @@ class Need < ActiveRecord::Base
 
   def record_decision_info
     if self.decision_made_at.nil? and self.reason_for_decision.present?
-      self.decision_made_at = Time.now
+      self.decision_made_at = Time.zone.now
       self.decision_maker = Thread.current[:current_user]
     end
   end
 
   def record_formatting_decision_info
     if self.formatting_decision_made_at.nil? and self.reason_for_formatting_decision.present?
-      self.formatting_decision_made_at = Time.now
+      self.formatting_decision_made_at = Time.zone.now
       self.formatting_decision_maker = Thread.current[:current_user]
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module NeedOTron
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join('app', 'locales', '*.{rb,yml}').to_s]

--- a/lib/tasks/check_for_bad_time_handling.rake
+++ b/lib/tasks/check_for_bad_time_handling.rake
@@ -1,0 +1,25 @@
+task :check_for_bad_time_handling do
+  directories = Dir.glob(File.join(Rails.root, '**', '*.rb'))
+  matching_files = directories.select do |filename|
+    match = false
+    File.open(filename) do |file|
+      match = file.grep(%r{Time\.(now|utc|parse)}).any?
+    end
+    match
+  end
+  if matching_files.any?
+    raise <<-MSG
+
+Avoid issues with daylight-savings time by always building instances of
+TimeWithZone and not Time. Use methods like:
+    Time.zone.now, Time.zone.parse, n.days.ago, m.hours.from_now, etc
+
+in preference to methods like:
+    Time.now, Time.utc, Time.parse, etc
+
+Files that contain bad Time handling:
+  #{matching_files.join("\n  ")}
+
+MSG
+  end
+end

--- a/spec/unit/needs_csv_spec.rb
+++ b/spec/unit/needs_csv_spec.rb
@@ -9,7 +9,7 @@ describe NeedsCsv do
   end
 
   it "should have a header row" do
-    csv = NeedsCsv.new([], Time.now).to_csv
+    csv = NeedsCsv.new([], Time.zone.now).to_csv
     data = CSV.parse(csv)
     data[0][0].should == "Id"
   end
@@ -19,7 +19,7 @@ describe NeedsCsv do
     @need.fact_checkers.create(email: 'matt@alphagov.co.uk')
     @need.fact_checkers.create(email: 'ben@alphagov.co.uk')
 
-    csv = NeedsCsv.new([], Time.now)
+    csv = NeedsCsv.new([], Time.zone.now)
     csv.fact_checkers(@need) == "matt@alphagov.co.uk, ben@alphagov.co.uk"
   end
 
@@ -27,7 +27,7 @@ describe NeedsCsv do
     wd = FactoryGirl.create(:writing_department, name: "Ministry of Magic")
     need = FactoryGirl.create(:need, writing_department: wd)
     need.reload
-    csv = NeedsCsv.new([need], Time.now).to_csv
+    csv = NeedsCsv.new([need], Time.zone.now).to_csv
     data = CSV.parse(csv)
     headers = data[0]
     rows = data[1..-1].map { |cols| Hash[headers.zip(cols)] }


### PR DESCRIPTION
Correctly display timestamps in the user's timezone (GMT or BST, not UTC).
