### PR TITLE
Fix Markdown formatting of commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Need-o-Tron is a Rails 3.1 application. It is built with ruby 1.9.2 and isn't
 guaranteed to work with any previous versions. To get up and running you'll
 need ruby and bundler installed. It should then just be a case of running:
 
-`bundle install
-rake db:setup
-rails server`
+    bundle install
+    rake db:setup
+    rails server
 
 To make it work properly you'll need to be running a correctly configured
 instance of solr. We're working on opening up more of our configuration files

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ against a separate app there's also a basic strategy for development use that wi
 simply use the first user in your database. To set that up you'll want something
 like:
 
-`% rails console
-User.create(:name => 'First User', :email => 'first@user.com', :uid => 1)
-exit`
+    % rails console
+    User.create(:name => 'First User', :email => 'first@user.com', :uid => 1)
+    exit


### PR DESCRIPTION
In the `README.md` file, commands were displayed in one line, due to wrong Markdown formatting, giving the impression that they were one single command.
