### PR TITLE
Remove reference to legacy support.cluster machine

### DIFF
--- a/config/initializers/tire.rb
+++ b/config/initializers/tire.rb
@@ -1,11 +1,4 @@
-if Rails.env.production?
-  Tire.configure {
-  	url "http://support.cluster:9200"
-    logger Rails.root.join("log/tire_#{Rails.env}.log")
-  }
-else
-  Tire.configure {
-    url "http://localhost:9200"
-    logger Rails.root.join("log/tire_#{Rails.env}.log")
-  }
-end
+Tire.configure {
+  url "http://localhost:9200"
+  logger Rails.root.join("log/tire_#{Rails.env}.log")
+}


### PR DESCRIPTION
This initializer is now specified in alphagov-deployment, so it is only
used here in development now. We are trying to encourage apps to move
away from support.cluster.
