### PR TITLE
Fix seed breakage: remove EvidenceTypes from seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,6 @@
 audiences = ['Everyone', 'Businesses', 'Professionals', 'Politicians/Govt', 'Parents', 'Carers', 'Young people', 'Disabled people', 'Overseas', 'Older people']
 audiences.each { |a| Audience.find_or_create_by_name(a) }
 
-["Search behaviour", "User request", "Legal framework", "Govt obligation", "Official channel", "Govt campaign"].each do |et_name|
-  EvidenceType.find_or_create_by_name(et_name)
-end
-
 ['Guide', 'Answer', 'Custom App', 'Decision Tree', 'Transaction (link)', 'Find nearest'].each do |kind|
   Kind.find_or_create_by_name(kind)
 end


### PR DESCRIPTION
EvidenceTypes table dissapeared after the "DropLegacySourceTables" migration
